### PR TITLE
Fix Windows build for native library

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -72,35 +72,20 @@ jobs:
           echo "📋 Checking generated native libraries:"
           find src/GrepSQL/runtimes/ -name "libpgquery_wrapper.*" -type f || echo "No native libraries found"
 
-      - name: Build for Windows (Placeholder)
+      - name: Build for Windows
         if: runner.os == 'Windows'
-        shell: cmd
+        shell: pwsh
         run: |
-          echo "🏗️ Building for Windows (partial support)..."
-          
-          REM Initialize submodules
           git submodule update --init --recursive
-          
-          REM Create placeholder directory structure
-          mkdir "src\GrepSQL\runtimes\win-x64\native" 2>nul
-          
-          REM Create a minimal dummy DLL to satisfy the .NET runtime
-          echo. > "src\GrepSQL\runtimes\win-x64\native\libpgquery_wrapper.dll"
-          
-          REM Build .NET project only
-          dotnet restore
-          dotnet build --configuration Release --no-restore
-          echo "⚠️ Windows build completed with placeholder native library"
+          ./scripts/build.ps1
 
       - name: Test (non-Windows)
         if: runner.os != 'Windows'
         run: dotnet test --configuration Release --no-build --verbosity normal
 
-      - name: Test (Windows - without native dependencies)
+      - name: Test (Windows)
         if: runner.os == 'Windows'
-        run: |
-          echo "Running limited tests on Windows..."
-          # dotnet test --configuration Release --no-build --verbosity normal --filter "Category!=RequiresNative"
+        run: dotnet test --configuration Release --no-build --verbosity normal
 
       - name: Publish GrepSQL Binary
         run: dotnet publish src/GrepSQL.CLI/GrepSQL/GrepSQL.csproj --configuration Release --runtime ${{ matrix.platform }} --self-contained true --output ./publish/${{ matrix.platform }} -p:PublishSingleFile=true -p:PublishTrimmed=true -p:IncludeNativeLibrariesForSelfExtract=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          submodules: recursive
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -53,26 +54,20 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential libc6-dev
 
-      - name: Run comprehensive build script
+      - name: Run build script (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          ./scripts/build.ps1
+
+      - name: Run comprehensive build script (Unix)
+        if: matrix.os != 'windows-latest'
         shell: bash
         run: |
-          # Skip entire native build on Windows - needs different toolchain
-          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-            echo "🏗️ Building for Windows (partial support)..."
-            echo "Skipping native library build on Windows - .NET code will be tested without native dependencies"
-            echo "Windows would need MSVC/Visual Studio build tools for native compilation"
-            
-            # Initialize submodules and build .NET only
-            git submodule update --init --recursive
-            dotnet restore
-            dotnet build --configuration Release --no-restore
-            exit 0
-          fi
-          
           echo "🏗️ Running comprehensive build script..."
           chmod +x scripts/build.sh
           ./scripts/build.sh
-          
+
           # Verify the build was successful
           echo "📋 Verifying build output:"
           find src/GrepSQL/runtimes/ -name "libpgquery_wrapper.*" -type f || echo "No native libraries found"
@@ -121,7 +116,18 @@ jobs:
             echo "Warning: Native library not found at src/GrepSQL/runtimes/$TARGET_RID/native/libpgquery_wrapper.$LIBRARY_EXT"
             echo "Available files in src/GrepSQL/runtimes/:"
             find src/GrepSQL/runtimes/ -name "*.so" -o -name "*.dylib" || echo "No native libraries found"
-          fi
+        fi
+
+      - name: Copy native libraries to test project (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          $TARGET_RID = 'win-x64'
+          $LIB_PATH = "src\GrepSQL\runtimes\$TARGET_RID\native\libpgquery_wrapper.dll"
+          $TEST_OUTPUT = "tests\GrepSQL.Tests\bin\Release\net9.0"
+          New-Item -ItemType Directory -Force -Path "$TEST_OUTPUT\runtimes\$TARGET_RID\native" | Out-Null
+          Copy-Item $LIB_PATH "$TEST_OUTPUT\runtimes\$TARGET_RID\native" -Force
+          Copy-Item $LIB_PATH $TEST_OUTPUT -Force
 
       - name: Run tests
         timeout-minutes: 10


### PR DESCRIPTION
## Summary
- ensure submodules are fetched in CI
- compile libpg_query wrapper on Windows
- run Windows build script in CI and release workflows
- copy native DLL for tests on Windows

## Testing
- `./scripts/build.sh`
- `dotnet test tests/GrepSQL.Tests/GrepSQL.Tests.csproj --no-build --verbosity quiet` *(fails: 53 failed, 23 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686fe2e45b3483248fa70e18ac783106